### PR TITLE
chore: Update API endpoint

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -11,5 +11,5 @@ export async function createPackage(query: string) {
     headers: myHeaders,
     body: graphql,
   };
-  return await fetch("http://localhost:8080/graphql", requestOptions)
+  return await fetch("http://localhost:8080", requestOptions)
 }


### PR DESCRIPTION
`/graphql` has now been changed to `/` (https://github.com/nestdotland/api/pull/15/commits/f985645c19dd49c7aa53e35f8a2e3892e114218e)